### PR TITLE
Pin the k8s version and use private version of orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,7 +438,7 @@ workflows:
           requires:
             - orb-tools/pack
       - orb-tools/publish-dev:
-          orb-name: shore-group/aws-eks
+          orb-name: h1nyc/aws-eks
           context: orb-publishing
           requires:
             - queue/block_workflow
@@ -665,7 +665,7 @@ workflows:
             - pre-orb-promotion-check
           filters: *orb_promotion_filters
       - promote-orb-into-production:
-          orb-name: shore-group/aws-eks
+          orb-name: h1nyc/aws-eks
           orb-ref: dev:${CIRCLE_SHA1:0:7}
           context: orb-publishing
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ orb_promotion_filters: &orb_promotion_filters
     only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
 
 orbs:
-  aws-eks: circleci/aws-eks@dev:alpha
+  aws-eks: circleci/aws-eks@1.1.0
   cli: circleci/circleci-cli@0.1.2
   helm: circleci/helm@1.2.0
   orb-tools: circleci/orb-tools@7.3.0
@@ -438,7 +438,7 @@ workflows:
           requires:
             - orb-tools/pack
       - orb-tools/publish-dev:
-          orb-name: circleci/aws-eks
+          orb-name: shore-group/aws-eks
           context: orb-publishing
           requires:
             - queue/block_workflow
@@ -665,7 +665,7 @@ workflows:
             - pre-orb-promotion-check
           filters: *orb_promotion_filters
       - promote-orb-into-production:
-          orb-name: circleci/aws-eks
+          orb-name: shore-group/aws-eks
           orb-ref: dev:${CIRCLE_SHA1:0:7}
           context: orb-publishing
           requires:

--- a/src/commands/update-kubeconfig-with-authenticator.yml
+++ b/src/commands/update-kubeconfig-with-authenticator.yml
@@ -67,7 +67,8 @@ steps:
   - when:
       condition: << parameters.install-kubectl >>
       steps:
-        - kubernetes/install
+        - kubernetes/install:
+            kubectl-version: v1.22.4
   - install-aws-iam-authenticator:
       release-tag: << parameters.authenticator-release-tag >>
   - aws-cli/install


### PR DESCRIPTION
### Description

Pins the k8s version and switch to using the private (shore-group) version of orbs.